### PR TITLE
[add]URLのコピーのためのショートカット機能を追加

### DIFF
--- a/js/content_script.js
+++ b/js/content_script.js
@@ -1,0 +1,16 @@
+document.addEventListener("keydown", event => {
+    if (event.ctrlKey && event.metaKey && event.key === "c"){
+        copyToClipboard()
+    }
+})
+
+function copyToClipboard(){
+    var url = location.href;
+    navigator.clipboard.writeText(url)
+    .then(() => {
+        console.log("URLのコピーに成功しました")
+    })
+    .catch(err => {
+        console.log("URLのコピーに失敗しました\n" + err)
+    })
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+    "name": "copy_shortcut",
+    "description": "ショートカットコマンド（Ctrl + Command + C）で現在のページのURLをコピーする機能です",
+    "version": "1.0.0",
+    "manifest_version": 3,
+    "permissions": [
+        "clipboardWrite"
+    ],
+    "content_scripts": [
+        {
+            "matches": [
+                "<all_urls>"
+            ],
+            "js": [
+                "js/content_script.js"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
”Ctrl+Command+C”を入力することで現在のページのURLをクリップボードにコピーをする機能を追加